### PR TITLE
Fix for monkey-patching Object.prototype

### DIFF
--- a/from-string.js
+++ b/from-string.js
@@ -10,7 +10,7 @@ function constantify(buffer) {
   var walk = astw(ast)
   var body = ast.body
   var clear = []
-  var list = {}
+  var list = Object.create(null)
 
   for (var i = 0; i < body.length; i += 1) {
     var node = body[i]


### PR DESCRIPTION
When transforming sources that contain `__proto__` tokens, this token was used as a key in the `list` object, which Javascript accepted as a valid implicit key, which led to unintended behavior.
